### PR TITLE
LSP builtins are auto-re-generated when pants.toml is saved

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,13 @@
           "default": "",
           "order": 2,
           "scope": "machine-overridable"
+        },
+        "suspenders.generateBuiltinsOnSave": {
+          "description": "Re-generate the BUILD LSP data when `pants.toml` has changes and then is saved.",
+          "type": "boolean",
+          "default": false,
+          "order": 3,
+          "scope": "machine-overridable"
         }
       }
     },

--- a/src/configuration.test.ts
+++ b/src/configuration.test.ts
@@ -1,10 +1,16 @@
 import { ConfigurationTarget, WorkspaceConfiguration } from "vscode";
-import { getBuildFileExtension, getPantsExecutable, ignoreLockfiles } from "./configuration";
+import {
+  getBuildFileExtension,
+  getPantsExecutable,
+  ignoreLockfiles,
+  shouldGenerateBuiltinsOnSave,
+} from "./configuration";
 
 test.each([
   [getPantsExecutable, "pants"],
   [getBuildFileExtension, ""],
   [ignoreLockfiles, true],
+  [shouldGenerateBuiltinsOnSave, false],
 ])(
   "configuration getter should return default value without a valid config",
   (fn, defaultValue) => {
@@ -17,6 +23,7 @@ test.each([
   [getPantsExecutable, "./pants_from_sources"],
   [getBuildFileExtension, ".pants"],
   [ignoreLockfiles, false],
+  [shouldGenerateBuiltinsOnSave, true],
 ])("configuration getter should use the user-specified settings when available", (fn, value) => {
   expect(fn(config(value))).toEqual(value);
 });

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -27,6 +27,12 @@ export function getBuildFileExtension(
   return returnDefaultIfUndefined(config.get<string>("buildFileExtension"), "").trim();
 }
 
+export function shouldGenerateBuiltinsOnSave(
+  config: WorkspaceConfiguration = workspace.getConfiguration(namespace)
+): string {
+  return returnDefaultIfUndefined(config.get<boolean>("generateBuiltinsOnSave"), false);
+}
+
 function returnDefaultIfUndefined(value: any, defaultValue: any) {
   if (value === undefined) {
     return defaultValue;


### PR DESCRIPTION
- This is contingent on a user setting (defaulted to False, as LSP generation is slow)
- Pants.toml must have a change, so spamming save won't do anything